### PR TITLE
Improved readability, fixed references, renamed files

### DIFF
--- a/draft-banghart-mile-rolie-csirt-00.xml
+++ b/draft-banghart-mile-rolie-csirt-00.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
 <?xml-stylesheet type="text/css" href="rfc7749.css"?>
-<rfc ipr="trust200811" category="info" docName="draft-rolie-CSIRT">  <!-- Working draft of supporting document for ROLIE -->
+<rfc ipr="trust200811" category="info" docName="draft-banghart-mile-rolie-csirt-00">  <!-- Working draft of supporting document for ROLIE -->
   <?rfc compact="yes"?>
   <?rfc subcompact="no"?>
   <?rfc toc="yes"?>

--- a/draft-ietf-mile-rolie-02.xml
+++ b/draft-ietf-mile-rolie-02.xml
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd"
-[
-<!ENTITY RFC4287 SYSTEM
-"http://xml.resource.org/public/rfc/bibxml/reference.RFC.4287.xml">
-<!ENTITY RFC2119 SYSTEM
-"http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
-<!ENTITY RFC5070 SYSTEM
-"http://xml.resource.org/public/rfc/bibxml/reference.RFC.5070.xml">
-<!ENTITY RFC5023 SYSTEM
-"http://xml.resource.org/public/rfc/bibxml/reference.RFC.5023.xml">
-<!ENTITY RFC5005 SYSTEM
-"http://xml.resource.org/public/rfc/bibxml/reference.RFC.5005.xml">
-<!ENTITY RFC7235 SYSTEM
-"http://xml.resource.org/public/rfc/bibxml/reference.RFC.7235.xml">
-<!ENTITY RFC6546 SYSTEM
-"http://xml.resource.org/public/rfc/bibxml/reference.RFC.6546.xml">
-]
->
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+  <!ENTITY RFC4287 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4287.xml">
+  <!ENTITY RFC2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
+  <!ENTITY RFC5070 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5070.xml">
+  <!ENTITY RFC5023 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5023.xml">
+  <!ENTITY RFC5005 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5005.xml">
+  <!ENTITY RFC7235 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7235.xml">
+  <!ENTITY RFC6546 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6546.xml">
+]>
 <?xml-stylesheet type="text/css" href="rfc7749.css"?>
 <rfc ipr="trust200902" category="info"
   docName="draft-ietf-mile-rolie-02">
@@ -44,8 +34,7 @@
         <email>jfield@pivotal.io</email>
       </address>
     </author>
-    <author initials="S.A." surname="Banghart"
-      fullname="Stephen A. Banghart">
+    <author initials="S.A." surname="Banghart" fullname="Stephen A. Banghart">
       <organization abbrev="NIST">National Institute of Standards and
         Technology</organization>
       <address>
@@ -63,163 +52,132 @@
     <area>Security</area>
     <workgroup>MILE Working Group</workgroup>
     <abstract>
-      <t> This document defines a resource-oriented approach to security
-        automation information sharing. Using this approach, producers
-        may share and exchange representations of security incidents,
-        attack indicators, software vulnerabilities, and other related
-        information as Web-addressable resources. Furthermore, consumers
-        and other stakeholders may access and search this security
-        content as needed, establishing a rapid and on-demand
-        information exchange network for restricted internal use or
-        public access repositories. This specification builds on and
-        extends the Atom Publishing Protocol and Atom Syndication Format
-        to transport and share security automation resource
-        representations.</t>
+      <t>This document defines a resource-oriented approach for security automation information
+        discovery and sharing. Using this approach, producers may publish, share and exchange
+        representations of security incidents, attack indicators, software vulnerabilities,
+        configuration checklists, and other security automation information as Web-addressable
+        resources. Furthermore, consumers and other stakeholders may access and search this security
+        information as needed, establishing a rapid and on-demand information exchange network for
+        restricted internal use or public access repositories. This specification extends the Atom
+        Publishing Protocol and Atom Syndication Format to transport and share security automation
+        resource representations.</t>
     </abstract>
     <note title="Contributing to this document">
       <!--RFC EDITOR - Please remove this note before publishing -->
       <t>The source for this draft is being maintained in GitHub.
-        Suggested changes should be submitted as pull requests at <eref
-          target="https://github.com/CISecurity/ROLIE"/>. Instructions
+        Suggested changes should be submitted as pull requests at <eref target="https://github.com/CISecurity/ROLIE"/>. Instructions
         are on that page as well. Editorial changes can be managed in
         GitHub, but any substantial issues need to be discussed on the
-        MILE mailing list. </t>
+        MILE mailing list.</t>
     </note>
   </front>
   <middle>
     <section title="Introduction" anchor="starting-intro">
-      <t> This document defines a resource-oriented approach to security
-        automation information sharing that follows the <xref
-          target="REST" format="title" pageno="false">REST</xref>
-        architectural style. In this approach, computer security
-        resources are maintained in web-accessible repositories
-        structured as <xref target="RFC4287">Atom Syndication
-          Format</xref> feeds. Representations of content are
-        categorized and organized into indexed collections, which are
-        requested by the consumer. As the set of resource collections
-        are forward facing, the consumer may search all available
-        content for which they are authorized to view and request that
-        which is desired. Granular authentication and access controls
-        permit only authorized consumers the ability to view, read, or
-        write to a given feed. This approach is in contrast to, and
-        meant to improve on, the traditional point-to-point messaging
-        system, in which consumers must request individual pieces of
-        information from a server following a triggering event. This
-        traditional approach creates a closed system of information
-        sharing that encourages duplication of effort and hinders
+      <t>This document defines a resource-oriented approach to security automation information
+        sharing that follows the <xref target="REST" format="title" pageno="false">REST</xref>
+        architectural style. In this approach, computer security resources are maintained in
+        web-accessible repositories structured as <xref target="RFC4287">Atom Syndication
+          Format</xref> feeds. Representations of content are categorized and organized into indexed
+        collections, which are requested by the consumer. As the set of resource collections are
+        forward facing, the consumer may search all available content for which they are authorized
+        to view and request that which is desired. Through use of granular authentication and access
+        controls, only authorized consumers may be permitted the ability to view, read, or write to
+        a given feed. This approach is in contrast to, and meant to improve on, the traditional
+        point-to-point messaging system, in which consumers must request individual pieces of
+        information from a server following a triggering event. The point-to-point approach creates
+        a closed system of information sharing that encourages duplication of effort and hinders
         automated security systems.</t>
-      <t>The goal of this document is to define the RESTful approach to
-        security communication with two primary intents: increasing
-        communication and sharing of incident reports, vulnerability
-        assessments, and other security content between producers,
-        operators, and consumers, as well as establishing a standardized
-        communication system to support automated computer security
-        systems.</t>
-      <t>In order to deal with the great variety in security resource
-        representations, this specification supports most current
-        representation formats by means of additional supplementary
-        documents. This primary document is payload format agnostic, and
-        defines the core requirements of all implementations. Those
-        seeking to implement each format should refer to the
-        specification for that format, found in section TODO. </t>
+      <t>The goal of this document is to define a RESTful approach to security information
+        communication with two primary intents: 1) increasing communication and sharing of incident
+        reports, vulnerability assessments, configuration checklists, and other security automation
+        information between producers, operators, and consumers; and 2) establishing a standardized
+        communication system to support automated computer security systems.</t>
+      <t>In order to deal with the great variety in security automation information types and
+        associated resource representations, this specification defines extension points that can be
+        used to add support for new information types and associated resource representations by
+        means of additional supplementary specification documents. This primary document is resource
+        representation agnostic, and defines the core requirements of all implementations. Those
+        seeking to provide support for specific security automation information types should refer
+        to the specification for that format described by the IANA registry found in section
+        TODO.</t>
     </section>
     <section title="Terminology" anchor="ext-terminology">
-      <t> The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL
+      <t>The key words "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL
         NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and
         "OPTIONAL" in this document are to be interpreted as described
         in <xref target="RFC2119"/>. Definitions for some of the common
         computer security-related terminology used in this document can
-        be found in Section 2 of <xref target="RFC5070"/>. </t>
+        be found in Section 2 of <xref target="RFC5070"/>.</t>
     </section>
     <section title="Background and Motivation" anchor="back-motive">
-      <t> It is well known that the field of threats to computer
-        security is evolving ever more rapidly as time goes on. As
-        software increases in complexity, the number of vulnerabilities
-        in our systems and networks increase exponentially. Threat
-        actors looking to exploit these vulnerabilities are making more
-        frequent and more widely distributed attacks across a large
-        variety of systems. The adoption of liberal information sharing
-        amongst attackers creates a window of as little as a few hours
-        between the discovery of a vulnerability and attacks on the
-        vulnerable system. As the skills and knowledge required to
-        identify and combat these attacks become more and more
-        specialized, even a well established and secure system may find
-        itself unable to quickly respond to an incident. Effective
-        identification of and response to a sophisticated attack
-        requires open cooperation and collaboration between defending
-        operators, software vendors, and even end-users.</t>
-      <t> Existing approaches to computer security information sharing
-        are based upon message exchange patterns that are
-        point-to-point, and event-driven. Sometimes, information that
-        may be useful to, and sharable with multiple peers is only made
-        available to peers after they have specifically requested it.
-        Unfortunately, a sharing peer may not know, a priori, what
-        information to request from another peer. Some exsisting systems
-        provide a mechanism for unsolicited information requests,
-        however these reports are again sent point-to-point, and must be
-        reviewed for relevance and then prioritized for action by the
-        recipient. Thus, distribution of some relevant information may
-        exhibit significant latency. </t>
-      <t> In order to adequately combat these evolving threats, computer
-        security resource producers should be enabled to share selected
-        information proactively as appropriate. Proactive sharing
-        greatly aids knowledge dissemination as well as improving
-        response times and usability.</t>
-      <t> For example, a security analyst would benefit by having the
-        ability to search a comprehensive collection of attack
-        indicators that have been published by a government agency, or
-        by another member of a sharing consortium. The representation of
-        each indicator may include links to the related resources,
-        enabling an appropriately authenticated and authorized analyst
-        to freely navigate the information space of indicators,
-        incidents, vulnerabilities, and other computer security domain
-        concepts as needed. In this way, an analyst can utilize the
-        super set of information made publicly available
-        effectively.</t>
-      <t> Consider also the case of an automated endpoint management
-        system attempting to proactively prevent software flaws from
-        adversely affecting systems. During its full network sweep, the
-        endpoint monitoring system would check each endpoint for
-        outdated or vulnerable software. This system would benefit from
-        having access to not only the software vendor's list of
-        vulnerabilities, but also vulnerabilities discovered by any
-        other security entity. An advanced system could even give back
-        to this sharing consortium by sharing any vulnerabilities that
-        it discovers. The natural conclusion of such a sharing network
-        is an automated security solution that can dynamically find and
-        collect information from a globally distributed web of
-        information repositories.</t>
+      <t>It is well known that the field of threats to computer security is evolving ever more
+        rapidly as time goes on. As software increases in complexity, the number of vulnerabilities
+        in systems and networks can increase exponentially. Threat actors looking to exploit these
+        vulnerabilities are making more frequent and more widely distributed attacks across a large
+        variety of systems. The adoption of liberal information sharing amongst attackers creates a
+        window of as little as a few hours between the discovery of a vulnerability and attacks on a
+        vulnerable system. As the skills and knowledge required to identify and combat these attacks
+        become more and more specialized, even a well established and secure system may find itself
+        unable to quickly respond to an incident. Effective identification of and response to a
+        sophisticated attack requires open cooperation and collaboration between defending
+        operators, software vendors, and end-users.</t>
+      <t>Existing approaches to computer security information sharing often use message exchange
+        patterns that are point-to-point, and event-driven. Sometimes, information that may be
+        useful to share with multiple peers is only made available to peers after they have
+        specifically requested it. Unfortunately, a sharing peer may not know, a priori, what
+        information to request from another peer. Some exsisting systems provide a mechanism for
+        unsolicited information requests, however these reports are again sent point-to-point, and
+        must be reviewed for relevance and then prioritized for action by the recipient, introducing
+        additional latency.</t>
+      <t>In order to adequately combat evolving threats, computer security information resource
+        providers should be enabled to share selected information proactively as appropriate.
+        Proactive sharing greatly aids knowledge dissemination, and improves response times and
+        usability.</t>
+      <t>For example, a security analyst can benefit by having the ability to search a comprehensive
+        collection of attack indicators that have been published by a government agency, or by
+        another member of a sharing consortium. The representation of each indicator may include
+        links to the related resources, enabling an appropriately authenticated and authorized
+        analyst to freely navigate the information space of indicators, incidents, vulnerabilities,
+        and other computer security domain concepts as needed. In this way, an analyst can more
+        effectively utilize the super set of information made publicly available.</t>
+      <t>Consider also the case of an automated endpoint management system attempting to proactively
+        prevent software flaws from compromising the security of the affected systems. During its
+        full network sweep, the endpoint monitoring system would check each endpoint for outdated or
+        vulnerable software. This system would benefit from having access to not only the software
+        vendor's list of vulnerabilities, but also vulnerabilities discovered by other vulnerability
+        researchers. An advanced system could even give back to this sharing consortium by sharing
+        any vulnerabilities that it discovers. The natural conclusion of such a sharing network is
+        an automated security solution that can dynamically find and collect information from a
+        globally distributed web of information repositories.</t>
       <t> The following section discusses additional specific technical
         issues that motivated the development of this alternative
-        approach. </t>
-      <section
-        title="Message-oriented versus Resource-oriented Architecture"
-        anchor="msg-vs-roa">
+        approach.</t>
+      <section title="Message-oriented versus Resource-oriented Architecture" anchor="msg-vs-roa">
         <t>The existing approaches to computer security information
           sharing are based upon message-oriented interactions. The
           following paragraphs explore some of the architectural
           constraints associated with message-oriented interactions and
-          consider the relative merits of an alternative model based on
-          a Resource-oriented architecture for use in some use case
-          scenarios. </t>
-        <t>ROLIE specifies a resource-oriented architecture that
-          attempts to address the issues present in a message-oriented
+          consider the relative merits of an alternative model based on a
+          Resource-oriented architecture for use in some use case
+          scenarios.</t>
+        <t>ROLIE specifies a resource-oriented architecture that attempts
+          to address the issues present in a message-oriented
           architecture.</t>
         <section title="Message-oriented Architecture" anchor="message">
-          <t> In general, message-based integration architectures may be
+          <t>In general, message-based integration architectures may be
             based upon either an RPC-style or a document-style binding.
             The message types defined by RID represent an example of an
-            RPC-style request. This approach imposes implied
-            requirements for conversational state management on both of
-            the communicating RID endpoint(s). Experience has shown that
-            this state management frequently becomes the limiting factor
-            with respect to the runtime scalability of an RPC-style
-            architecture. </t>
-          <t> In addition, the practical scalability of a peer-to-peer
+            RPC-style request. This approach imposes implied requirements
+            for conversational state management on both of the
+            communicating RID endpoint(s). Experience has shown that this
+            state management frequently becomes the limiting factor with
+            respect to the runtime scalability of an RPC-style
+            architecture.</t>
+          <t>In addition, the practical scalability of a peer-to-peer
             message-based approach will be limited by the administrative
             procedures required to manage O(N^2) trust relationships and
-            at least O(N) policy groups. </t>
-          <t> As long as the number of participating entities in an
+            at least O(N) policy groups.</t>
+          <t>As long as the number of participating entities in an
             information sharing consortium is limited to a relatively
             small number of nodes (i.e., O(2^N), where N &lt; 5), these
             scalability constraints may not represent a critical
@@ -227,169 +185,134 @@
             significantly larger number of participating peers, a
             different architectural approach will be required. Towards
             the goal to create a large-scale network of entities sharing
-            information, this traditional architecture only creates
-            small and isolated groupings of sharing, encouraging effort
-            duplication between these sharing islands. One alternative
-            to the message-based approach that has demonstrated
-            scalability and a high degree of connectedness is the <xref
-              target="REST">REST</xref> architectural style.</t>
+            information, this traditional architecture only creates small
+            and isolated groupings of sharing, encouraging effort
+            duplication between these sharing islands. One alternative to
+            the message-based approach that has demonstrated scalability
+            and a high degree of connectedness is the <xref target="REST">REST</xref> architectural style.</t>
         </section>
-        <section title="Resource-Oriented Architecture"
-          anchor="roa-benefits">
-          <t> Applying the REST architectural style to the problem
-            domain of security information sharing would take the
-            approach of exposing information in any relevant type as
-            simple Web-addressable resources. Each provider would then
-            maintain their own repository of this data, with public and
-            private sections as needed. Any producer or consumer can
-            then discover these repositories, search for relevant feeds,
-            and pull information from them. By using this approach, an
-            organization can more quickly and easily share relevant data
-            representations with a much larger and potentially more
-            diverse constituency. A consumer may leverage virtually any
-            available HTTP user agent in order to make requests of the
-            service provider. This improved ease of use enables broader
-            participation, thereby improving security for everyone. </t>
-          <t> A key interoperability aspect of any RESTful Web service
-            is regarding the available resource representations. For
-            example, clients may request that a given resource
-            representation be returned as either XML or JSON, or as some
-            other specification. In order to enable back-compatibility
-            and interoperability with existing implementations, the
-            RESTful approach allows the provider to make differing
-            formats available proactively, allowing the consumer to
-            simply select the version that best suits them without any
-            further requests of the providing server.</t>
-          <t> Finally, an important principle of the REST architectural
-            style is the focus on hypermedia as the engine of
-            application state (HATEOAS). Rather than the server
-            maintaining conversational state for each client context,
-            the server will instead include a suitable set of hyperlinks
-            in the resource representation that is returned to the
-            client. In this way, the server remains stateless with
-            respect to a series of client requests. The included
-            hyperlinks provide the client with a specific set of
-            permitted state transitions. Using these links the client
-            may perform an operation, such as updating or deleting the
-            resource representation. The client may also be provided
-            with hypertext links that can be used to navigate to any
-            related resource. For example, the resource representation
-            for an incident object may contain links to the related
-            indicator resource(s). </t>
-          <section
-            title="A Resource-Oriented Use Case: &quot;Mashup&quot;"
-            anchor="mashup">
-            <t> In this section we consider a non-normative example use
-              case scenario for creating a computer security "mashup". </t>
-            <t> A producer creates and maintains a feed of information
-              on threat actors, whilst another creates and maintains a
-              feed of attack indicators. Each has authorized a large
-              consortium of security analysts to access these feeds as
-              they see fit. Any one of these analysts can then make
-              HTTP(s) requests to the servers to collect sets of
-              information from each provider. The resulting correlations
-              may yield new insights that enable a more timely and
-              effective defensive response. Of course, this report may,
-              in turn, be made available to others as a new
-              Web-addressable resource, reachable via another URL. By
-              employing the RESTful Web service approach the
-              effectiveness of the collaboration amongst a consortium of
-              cyber security stakeholders can be greatly improved. </t>
+        <section title="Resource-Oriented Architecture" anchor="roa-benefits">
+          <t>Applying the REST architectural style to the problem domain of security information
+            sharing involves exposing information in any relevant type as simple Web-addressable
+            resources. Each provider maintains their own repository of data, with public and private
+            sections as needed. Any producer or consumer can then discover these repositories,
+            search for relevant feeds, and pull information from them. By using this approach, an
+            organization can more quickly and easily share relevant data representations with a much
+            larger and potentially more diverse constituency. A consumer may leverage virtually any
+            available HTTP user agent in order to make requests of the service provider. This
+            improved ease of use enables more rapid adoption
+            and broader participation, thereby improving security for everyone.</t>
+          <t>A key aspect of any RESTful Web service is the ability provide multiple resource
+            representations. For example, clients may request that a given resource representation
+            be returned as XML, JSON, or in some other format. In order to enable
+            backwards-compatibility and interoperability with existing implementations, the RESTful
+            approach allows the provider to make differing formats available proactively, allowing
+            the consumer to simply select the version that best suits them.</t>
+          <t>Finally, an important principle of the REST architectural style is the focus on
+            hypermedia as the engine of application state (HATEOAS). Rather than the server
+            maintaining conversational state for each client, the server will instead include a
+            suitable set of hyperlinks in the resource representation that is returned to the
+            client. The included hyperlinks provide the client with a specific set of permitted
+            state transitions. Using these links the client may perform an operation, such as
+            updating or deleting the resource representation. The client may also be provided with
+            hypertext links that can be used to navigate to any related resource. For example, the
+            resource representation for an incident object may contain links to the related
+            indicator resource(s). In this way, the server remains stateless with respect to a
+            series of client requests.</t>
+          <section title="A Resource-Oriented Use Case: &quot;Mashup&quot;" anchor="mashup">
+            <t>In this section we consider an example scenario for creating a computer security
+              "mashup".</t>
+            <t>A producer creates and maintains a feed of information on threat actors, whilst
+              another creates and maintains a feed of attack indicators. Each has authorized a large
+              consortium of security analysts to access these feeds as they see fit. Any one of
+              these analysts can then make HTTP(s) requests to the servers to collect sets of
+              information from each provider. The resulting correlations may yield new insights that
+              enable a more timely and effective defensive response. Of course, this report may, in
+              turn, be made available to others as a new Web-addressable resource, reachable via
+              another URL. By exposing information using the RESTful approach in this way, the
+              effectiveness of the collaboration amongst a consortium of cyber security stakeholders
+              can be greatly improved.</t>
           </section>
         </section>
       </section>
     </section>
-    <section
-      title=" Atom Publication Protocol and Atom Syndication Format TODO"
-      anchor="atom">
-      <t> This document specifies the use of Atom Syndication Format and
-        Atom Publishing Protocol as the mechanism for implementing a
-        RESTful architecture</t>
-      <t> As described in <xref target="RFC5023">Atom Publishing
-          Protocol</xref>, an Atom Service Document is an XML-based
+    <section title="Use of the Atom Publishing Protocol and Atom Syndication Format TODO" anchor="atom">
+      <t>This section specifies the use of the Atom Syndication Format and Atom Publishing Protocol (AtomPub)
+        as the mechanism for implementing a RESTful architecture</t>
+      <t>As described in <xref target="RFC5023">AtomPub</xref> section 8, a Service Document is an XML-based
         document format that allows a client to dynamically discover the
-        collections provided by a publisher. </t>
-      <t> As described in <xref target="RFC4287">Atom Syndication
-          Format</xref>, Atom is an XML-based document format that
-        describes lists of related information items known as
-        collections, or "feeds". Each feed document contains a
-        collection of zero or more related information items called
-        "member entries" or "entries". </t>
-      <t> When applied to the problem domain of security automation
-        information sharing, an Atom feed may be used to represent any
-        meaningful collection of information resources such as a set of
-        configuration checklists or software vulnerabilities. Each entry
-        in a feed could then represent an individual resource as
-        appropriate. Additional feeds could be used to represent other
-        meaningful and useful collections of security automation
-        resources. A feed may be categorized, and any feed may contain
-        information from zero or more categories. </t>
-      <t>This document assumes that the reader has an understanding of
-        both the AtomPub and Atom Syndication Format specifications.</t>
-    </section>
-    <section title=" Normative Requirements TODO"
-      anchor="normative-requirements">
-      <t>This section provides the NORMATIVE requirements for using Atom
-        format and Atom Pub as a RESTful binding for security automation
-        information sharing.</t>
+        collections provided by a publisher.</t>
+      <t>As described in <xref target="RFC4287">Atom Syndication Format</xref>, an Atom feed is an XML-based
+        document format that describes a list of related information items, also known as a collection.
+        Each feed document contains a collection of zero or more related information items
+        individually called a "member entry" or "entry".</t>
+      <t>When applied to the problem domain of security automation information sharing, an Atom feed
+        may be used to represent any meaningful collection of information resources including a set
+        of configuration checklists or software vulnerabilities. Each entry in a feed represents an
+        individual resource, such as a specific checklist or software vulnerability record.
+        Additional feeds could be used to represent collections of other meaningful and useful
+        security automation resources. A feed may be categorized and may contain information from
+        zero or more categories.
+        The
+        naming scheme and the semantic meaning of the terms used to identify an Atom category are
+        application-defined.</t>
+      <t>This document assumes that the reader has an understanding of both the AtomPub and Atom
+        Syndication Format specifications..</t>
+      <t>The remainder of this section provides requirements for using the Atom Syndication Format and
+        AtomPub as a RESTful binding for security automation information sharing.</t>
       <section title="Atom Requirements" anchor="atom-req">
         <t>Implementations of this specification MUST implement all
           requirements specified in Atom Publishing Protocol and the
           Atom Syndication Format. (TODO: work on a more normative and
           perhaps constrained requirement.)</t>
       </section>
-      <section title="Transport Layer Security"
-        anchor="normative-transport-sec">
-        <t>Implementations MUST support server-authenticated TLS. </t>
+      <section title="Transport Layer Security" anchor="normative-transport-sec">
+        <t>Implementations MUST support server-authenticated TLS.</t>
         <t>Implementations MAY support mutually authenticated TLS.</t>
       </section>
-      <section title="Archiving and Paging"
-        anchor="normative-archive-page">
+      <section title="Archiving and Paging" anchor="normative-archive-page">
         <t>A feed can contain an arbitrary number of entries. In some
           cases, the complete response to a given query may consist of a
           logical result set that contains a large number of entries. As
           a practical matter, the full result set will likely need to be
-          divided into more manageable portions. For example, a query
-          may produce a full result set that may need to be grouped into
-          logical pages, for purposes of rendering on a user interface. </t>
-        <t> An historical feed may need to be stable, and/or divided
-          into some defined epochs. Implementations SHOULD support the
+          divided into more manageable portions. For example, a query may
+          produce a full result set that may need to be grouped into
+          logical pages, for purposes of rendering on a user interface.</t>
+        <t>An historical feed may need to be stable, and/or divided into
+          some defined epochs. Implementations SHOULD support the
           mechanisms described in <xref target="RFC5005">Feed Paging and
             Archiving</xref> to provide capabilities for paging and
-          archiving of feeds. </t>
+          archiving of feeds.</t>
       </section>
       <section title="User Authentication" anchor="normative-user-auth">
         <t>Implementations MUST support user authentication. User
           authentication MAY be enabled for specific feeds.</t>
         <t>Implementations MAY support more than one client
-          authentication method. </t>
+          authentication method.</t>
         <t> Servers participating in an information sharing consortium
           and supporting interactive user logins by members of the
-          consortium SHOULD support client authentication via a
-          federated identity scheme as per SAML 2.0. </t>
-        <t> Implementations MAY support client authenticated TLS. </t>
+          consortium SHOULD support client authentication via a federated
+          identity scheme as per SAML 2.0.</t>
+        <t>Implementations MAY support client authenticated TLS.</t>
       </section>
       <section title="User Authorization" anchor="normative-user-authz">
         <t>This document does not mandate the use of any specific user
           authorization mechanisms. However, service implementers SHOULD
           provide appropriate authorization checking for all resource
           accesses, including individual Atom Entries, Atom Feeds, and
-          Atom Service Documents. </t>
-        <t> Authorization for a resource MAY be adjudicated based on the
-          value(s) of the associated Atom &lt;category&gt; element(s). </t>
-        <t> Any use of the &lt;category&gt; element(s) as an input to an
+          Atom Service Documents.</t>
+        <t>Authorization for a resource MAY be adjudicated based on the
+          value(s) of the associated Atom &lt;category&gt; element(s).</t>
+        <t>Any use of the &lt;category&gt; element(s) as an input to an
           authorization policy decision MUST include both the "scheme"
-          and "term" attributes contained therein. As described in <xref
-            target="category-mapping"/> below, the namespace of the
+          and "term" attributes contained therein. As described in <xref target="category-mapping"/> below, the namespace of the
           "term" attribute is scoped by the associated "scheme"
-          attribute. </t>
+          attribute.</t>
       </section>
       <section title="HTTP methods" anchor="inc-http-methods">
-        <t>The following table defines the <xref target="RFC7235"
-            >HTTP</xref> uniform interface methods supported by this
-          specification: </t>
-        <texttable anchor="http-methods-table"
-          title="Uniform Interface for Resource-Oriented Lightweight Indicator Exchange">
+        <t>The following table defines the <xref target="RFC7235">HTTP</xref>
+          uniform interface methods supported by this specification:</t>
+        <texttable anchor="http-methods-table" title="Uniform Interface for Resource-Oriented Lightweight Indicator Exchange">
           <ttcol align="left">HTTP method</ttcol>
           <ttcol align="left">Description</ttcol>
           <c>GET</c>
@@ -412,24 +335,23 @@
           <c>PATCH</c>
           <c>Support TBD.</c>
         </texttable>
-        <t>Clients MUST be capable of recognizing and prepared to
-          process any standard HTTP status code, as defined in <xref
-            target="RFC7235"/></t>
+        <t>Clients MUST be capable of recognizing and prepared to process
+          any standard HTTP status code, as defined in <xref target="RFC7235"/></t>
       </section>
       <section title="Service Discovery">
         <t>This specification requires that an implementation MUST
           publish an Atom Service Document that describes the set of
-          security information sharing feeds that are provided. </t>
-        <t> The service document SHOULD be discoverable via the
+          security information sharing feeds that are provided.</t>
+        <t>The service document SHOULD be discoverable via the
           organization's Web home page or another well-known public
-          resource. </t>
-        <t> The service document SHOULD (TODO: MUST?) be located at the
+          resource.</t>
+        <t>The service document SHOULD (TODO: MUST?) be located at the
           standardized location "SERVERROOT/ROLIE/servicedocument". This
-          document MAY be a link to the actual service document. </t>
-        <t> When deploying a service document for use by a closed
+          document MAY be a link to the actual service document.</t>
+        <t>When deploying a service document for use by a closed
           consortium, the service document MAY also be digitally signed
           and/or encrypted, using XML DigSig and/or XML Encryption,
-          respectively. </t>
+          respectively.</t>
         <section title="Workspaces">
           <t>The service document MAY include multiple workspaces. Any
             producer providing both public feeds and private feeds MUST
@@ -454,13 +376,12 @@
         <t>For category requirements see Section 6, Content Model.</t>
       </section>
       <section title="Link Relations">
-        <t> In addition to the standard Link Relations defined by the
+        <t>In addition to the standard Link Relations defined by the
           Atom specification, this specification defines the following
           additional Link Relation terms, which are introduced
           specifically in support of the Resource-Oriented Lightweight
-          Information Exchange protocol. </t>
-        <texttable anchor="link-relations-table"
-          title="Link Relations for Resource-Oriented Lightweight Indicator Exchange">
+          Information Exchange protocol.</t>
+        <texttable anchor="link-relations-table" title="Link Relations for Resource-Oriented Lightweight Indicator Exchange">
           <ttcol align="left">Name</ttcol>
           <ttcol align="left">Description</ttcol>
           <ttcol align="left">Conformance</ttcol>
@@ -481,29 +402,29 @@
             of information that are associated with the resource.</c>
           <c>MUST</c>
         </texttable>
-        <t> Unless specifically registered with IANA these short names
+        <t>Unless specifically registered with IANA these short names
           MUST be fully qualified via concatenation with a base-uri. An
-          appropriate base-uri could be established via agreement
-          amongst the members of an information sharing consortium. For
-          example, the rel="indicators" relationship would become
-          rel="http://www.example.org/rolie/incidents/relationships/indicators." </t>
-        <t> An Atom Entry MAY include additional link relationships not
+          appropriate base-uri could be established via agreement amongst
+          the members of an information sharing consortium. For example,
+          the rel="indicators" relationship would become
+          rel="http://www.example.org/rolie/incidents/relationships/indicators."</t>
+        <t>An Atom Entry MAY include additional link relationships not
           specified here. If a client encounters a link relationship of
           an unknown type the client MUST ignore the offending link and
-          continue processing the remaining resource representation as
-          if the offending link element did not appear. </t>
+          continue processing the remaining resource representation as if
+          the offending link element did not appear.</t>
       </section>
       <section title="Security Requirements TODO">
         <t>AUTHOR NOTE: Authorization and Authentication requirements
           need to be hashed out</t>
-        <t>All security measures MUST be enforced at the source, that
-          is, a provider SHALL NOT return any feed content or member
-          entry content for which the client identity has not been
-          specifically authenticated, authorized, and audited. </t>
-        <t> Sharing communities that have a requirement for forward
+        <t>All security measures MUST be enforced at the source, that is,
+          a provider SHALL NOT return any feed content or member entry
+          content for which the client identity has not been specifically
+          authenticated, authorized, and audited.</t>
+        <t>Sharing communities that have a requirement for forward
           message security (such that client systems are required to
           participate in providing message level security and/or
-          distributed authorization policy enforcement), MUST use TODO. </t>
+          distributed authorization policy enforcement), MUST use TODO.</t>
         <t>The implementation details of the authorization scheme chosen
           by a ROLIE-compliant provider are out of scope for this
           specification. Implementers are free to choose any suitable
@@ -514,18 +435,17 @@
       <section title="Date Mapping">
         <t>The Atom feed &lt;updated&gt; element MUST be populated with
           the current time at the instant the feed representation was
-          generated. </t>
+          generated.</t>
       </section>
       <section title="Search">
-        <t> Implementers MUST support <xref target="opensearch"
-            >OpenSearch 1.1</xref> as the mechanism for describing how
-          clients may form search requests. </t>
-        <t> Implementers MUST provide a link with a relationship type of
+        <t>Implementers MUST support <xref target="opensearch">OpenSearch 1.1</xref> as the mechanism for describing how
+          clients may form search requests.</t>
+        <t>Implementers MUST provide a link with a relationship type of
           "search". This link SHALL return an Open Search Description
-          Document as defined in OpenSearch 1.1. </t>
-        <t> Implementers MUST fully qualify all OpenSearch URL template
+          Document as defined in OpenSearch 1.1.</t>
+        <t>Implementers MUST fully qualify all OpenSearch URL template
           parameter names using the defined XML namespaces, as
-          appropriate. </t>
+          appropriate.</t>
       </section>
       <section title="/ (forward slash) Resource URL" anchor="rid-ref">
         <t>The "/" resource MAY be provided for compatibility with
@@ -546,7 +466,7 @@
       </section>
     </section>
     <section title="Content Model" anchor="content-model">
-      <t> This specification does not require a particular content
+      <t>This specification does not require a particular content
         format, rather, it provides an IANA table of supported formats.
         Each supported category of information has a number of supported
         formats. Each format has a document describing requirements for
@@ -625,10 +545,10 @@
         lightweight information exchange using HTTP, TLS, Atom Syndicate
         Format, and Atom Publishing Protocol. As such, implementers must
         understand the security considerations described in those
-        specifications. </t>
-      <t> In addition, there are a number of additional security
-        considerations that are unique to this specification. </t>
-      <t> The approach described herein is based upon all policy
+        specifications.</t>
+      <t>In addition, there are a number of additional security
+        considerations that are unique to this specification.</t>
+      <t>The approach described herein is based upon all policy
         enforcements being implemented at the point when a resource
         representation is created. As such, producers sharing cyber
         security information using this specification must take care to
@@ -643,12 +563,9 @@
         authentication solution, such as TLS client certificates, or a
         risk-based or multi-factor approach. In general, trust in the
         sharing consortium will depend upon the members maintaining
-        adequate user authentication mechanisms. </t>
-      <t> Collaborating consortiums may benefit from the adoption of a
-        federated identity solution, such as those based upon <xref
-          target="SAML-core">SAML-core</xref> and <xref
-          target="SAML-bind">SAML-bind</xref> and <xref
-          target="SAML-prof">SAML-prof</xref> for Web-based
+        adequate user authentication mechanisms.</t>
+      <t>Collaborating consortiums may benefit from the adoption of a
+        federated identity solution, such as those based upon <xref target="SAML-core">SAML-core</xref> and <xref target="SAML-bind">SAML-bind</xref> and <xref target="SAML-prof">SAML-prof</xref> for Web-based
         authentication and cross-organizational single sign-on.
         Dependency on a trusted third party identity provider implies
         that appropriate care must be exercised to sufficiently secure
@@ -657,40 +574,37 @@
         Potential mitigations include deployment of a federation-aware
         identity provider that is under the control of the information
         sharing consortium, with suitably stringent technical and
-        management controls. </t>
-      <t> Authorization of resource representations is the
-        responsibility of the source system, i.e. based on the
-        authenticated user identity associated with an HTTP(S) request.
-        The required authorization policies that are to be enforced must
-        therefore be managed by the security administrators of the
-        source system. Various authorization architectures would be
-        suitable for this purpose, such as <eref
-          target="http://csrc.nist.gov/groups/SNS/rbac/">RBAC</eref>
-        and/or ABAC, as embodied in <xref target="XACML">XACML</xref>.
-        In particular, implementers adopting XACML may benefit from the
+        management controls.</t>
+      <t>Authorization of resource representations is the responsibility
+        of the source system, i.e. based on the authenticated user
+        identity associated with an HTTP(S) request. The required
+        authorization policies that are to be enforced must therefore be
+        managed by the security administrators of the source system.
+        Various authorization architectures would be suitable for this
+        purpose, such as <eref target="http://csrc.nist.gov/groups/SNS/rbac/">RBAC</eref>
+        and/or ABAC, as embodied in <xref target="XACML">XACML</xref>. In
+        particular, implementers adopting XACML may benefit from the
         capability to represent their authorization policies in a
-        standardized, interoperable format. </t>
-      <t> Additional security requirements such as enforcing
-        message-level security at the destination system could
-        supplement the security enforcements performed at the source
-        system, however these destination-provided policy enforcements
-        are out of scope for this specification. Implementers requiring
-        this capability should consider leveraging, e.g. the
-        &lt;RIDPolicy&gt; element in the RID schema. Refer to RFC6545
-        section 9 for more information. </t>
-      <t> When security policies relevant to the source system are to be
-        enforced at both the source and destination systems,
-        implementers must take care to avoid unintended interactions of
-        the separately enforced policies. Potential risks will include
-        unintended denial of service and/or unintended information
-        leakage. These problems may be mitigated by avoiding any
-        dependence upon enforcements performed at the destination
-        system. When distributed enforcement is unavoidable, the usage
-        of a standard language (e.g. XACML) for the expression of
-        authorization policies will enable the source and destination
-        systems to better coordinate and align their respective policy
-        expressions. </t>
-      <t> Adoption of the information sharing approach described in this
+        standardized, interoperable format.</t>
+      <t>Additional security requirements such as enforcing
+        message-level security at the destination system could supplement
+        the security enforcements performed at the source system, however
+        these destination-provided policy enforcements are out of scope
+        for this specification. Implementers requiring this capability
+        should consider leveraging, e.g. the &lt;RIDPolicy&gt; element in
+        the RID schema. Refer to RFC6545 section 9 for more information.</t>
+      <t>When security policies relevant to the source system are to be
+        enforced at both the source and destination systems, implementers
+        must take care to avoid unintended interactions of the separately
+        enforced policies. Potential risks will include unintended denial
+        of service and/or unintended information leakage. These problems
+        may be mitigated by avoiding any dependence upon enforcements
+        performed at the destination system. When distributed enforcement
+        is unavoidable, the usage of a standard language (e.g. XACML) for
+        the expression of authorization policies will enable the source
+        and destination systems to better coordinate and align their
+        respective policy expressions.</t>
+      <t>Adoption of the information sharing approach described in this
         document will enable users to more easily perform correlations
         across separate, and potentially unrelated, cyber security
         information providers. A client may succeed in assembling a data
@@ -708,14 +622,14 @@
         appropriate vetting of the client at account provisioning time.
         In addition, any increase in the risk of this type of abuse
         should be offset by the corresponding increase in effectiveness
-        that this specification affords to the defenders. </t>
-      <t> While it is a goal of this specification to enable more agile
+        that this specification affords to the defenders.</t>
+      <t>While it is a goal of this specification to enable more agile
         cyber security information sharing across a broader and varying
         constituency, there is nothing in this specification that
         necessarily requires this type of deployment. A cyber security
         information sharing consortium may chose to adopt this
         specification while continuing to operate as a gated community
-        with strictly limited membership. </t>
+        with strictly limited membership.</t>
     </section>
 
     <section title="Acknowledgements" anchor="acknowledgements">
@@ -728,116 +642,154 @@
   </middle>
   <back>
     <references title="Normative References"> &RFC4287; &RFC2119;
-      &RFC5070; &RFC5023; &RFC5005; &RFC7235; &RFC6546; <reference
+      &RFC5070; &RFC5023; &RFC5005; &RFC7235; &RFC6546;
+      <reference
         anchor="opensearch"
         target="http://www.opensearch.org/Specifications/OpenSearch/1.1">
         <front>
           <title>OpenSearch 1.1 draft 5 specification</title>
-          <author initials="D." surname="Clinton"
-            fullname="Dewitt Clinton">
-            <organization abbrev="OpenSearch"> OpenSearch Community
-            </organization>
+          <author initials="D." surname="Clinton" fullname="Dewitt Clinton">
+            <organization abbrev="OpenSearch">OpenSearch Community</organization>
           </author>
           <date year="2011"/>
         </front>
       </reference>
-      <reference anchor="SAML-core"
-        target="http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf">
+      <reference anchor="SAML-core" target="http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf">
         <front>
-          <title>Assertions and Protocols for the OASIS Security
-            Assertion Markup Language (SAML) V2.0 </title>
-          <author initials="S." surname="Cantor" fullname="Scott Cantor">
-            <organization/>
+          <title>Assertions and Protocol for the OASIS Security Assertion Markup Language
+            (SAML) V2.0</title>
+          <author fullname="Scott Cantor" initials="S." surname="Cantor">
+            <organization>Internet2</organization>
+            <address>
+              <email>cantor.2@osu.edu</email>
+            </address>
           </author>
-          <author initials="J." surname="Kemp" fullname="John Kemp">
-            <organization/>
+          <author fullname="John Kemp" initials="J." surname="Kemp">
+            <organization>Nokia</organization>
+            <address>
+              <email>John.Kemp@nokia.com</email>
+            </address>
           </author>
-          <author initials="R." surname="Philpott"
-            fullname="Rob Philpott">
-            <organization/>
+          <author fullname="Rob Philpott" initials="R." surname="Philpott">
+            <organization>RSA Security</organization>
+            <address>
+              <email>rphilpott@rsasecurity.com</email>
+            </address>
           </author>
-          <author initials="E." surname="Mahler" fullname="Eve Mahler">
-            <organization/>
+          <author fullname="Eve Maler" initials="E." surname="Maler">
+            <organization>Sun Microsystems</organization>
+            <address>
+              <email>eve.maler@sun.com</email>
+            </address>
           </author>
-          <date day="15" month="March" year="2005"/>
+          <date year="2005" month="March"/>
         </front>
-        <seriesInfo name="OASIS Standard" value=""/>
+        <seriesInfo name="OASIS Standard" value="saml-core-2.0-os"/>
+        <format type="PDF" target="http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf"/>
       </reference>
-      <reference anchor="SAML-prof"
-        target="http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf">
+      <reference anchor="SAML-prof" target="http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf">
         <front>
-          <title>Profiles for the OASIS Security Assertion Markup
-            Language (SAML) V2.0</title>
-          <author initials="J." surname="Hughes" fullname="John Hughes">
-            <organization/>
+          <title>Profiles for the OASIS Security Assertion Markup Language
+            (SAML) V2.0</title>
+          <author fullname="John Hughes" initials="J." surname="Hughes">
+            <organization>Altos Origin</organization>
+            <address>
+              <email></email>
+            </address>
           </author>
-          <author initials="S." surname="Cantor" fullname="Scott Cantor">
-            <organization/>
+          <author fullname="Scott Cantor" initials="S." surname="Cantor">
+            <organization>Internet2</organization>
+            <address>
+              <email>cantor.2@osu.edu</email>
+            </address>
           </author>
-          <author initials="J." surname="Hodges" fullname="Jeff Hodges">
-            <organization/>
+          <author fullname="Jeff Hodges" initials="J." surname="Hodges">
+            <organization>NeuStar</organization>
+            <address>
+              <email>Jeff.Hodges@neustar.biz</email>
+            </address>
           </author>
-          <author initials="F." surname="Hirsch"
-            fullname="Frederick Hirsch">
-            <organization/>
+          <author fullname="Frederick Hirsch" initials="F." surname="Hirsch">
+            <organization>Nokia</organization>
+            <address>
+              <email>Frederick.Hirsch@nokia.com</email>
+            </address>
           </author>
-          <author initials="P." surname="Mishra"
-            fullname="Prateek Mishra">
-            <organization/>
+          <author fullname="Prateek Mishra" initials="P." surname="Mishra">
+            <organization>Principal Identity</organization>
+            <address>
+              <email>pmishra@principalidentity.com</email>
+            </address>
           </author>
-          <author initials="R." surname="Philpott"
-            fullname="Rob Philpott">
-            <organization/>
+          <author fullname="Rob Philpott" initials="R." surname="Philpott">
+            <organization>RSA Security</organization>
+            <address>
+              <email>rphilpott@rsasecurity.com</email>
+            </address>
           </author>
-          <author initials="E." surname="Mahler" fullname="Eve Mahler">
-            <organization/>
+          <author fullname="Eve Maler" initials="E." surname="Maler">
+            <organization>Sun Microsystems</organization>
+            <address>
+              <email>eve.maler@sun.com</email>
+            </address>
           </author>
-          <date day="15" month="March" year="2005"/>
+          <date year="2005" month="March"/>
         </front>
-        <seriesInfo name="OASIS Standard" value=""/>
+        <seriesInfo name="OASIS Standard" value="OASIS.saml-profiles-2.0-os"/>
+        <format type="PDF" target="http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf"/>
       </reference>
-      <reference anchor="SAML-bind"
-        target="http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf">
+      <reference anchor="SAML-bind" target="http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf">
         <front>
-          <title>Bindings for the OASIS Security Assertion Markup
-            Language (SAML) V2.0 </title>
-          <author initials="S." surname="Cantor" fullname="Scott Cantor">
-            <organization/>
+          <title>Bindings for the OASIS Security Assertion Markup Language
+            (SAML) V2.0</title>
+          <author fullname="Scott Cantor" initials="S." surname="Cantor">
+            <organization>Internet2</organization>
+            <address>
+              <email>cantor.2@osu.edu</email>
+            </address>
           </author>
-          <author initials="F." surname="Hirsch"
-            fullname="Frederick Hirsch">
-            <organization/>
+          <author fullname="Frederick Hirsch" initials="F." surname="Hirsch">
+            <organization>Nokia</organization>
+            <address>
+              <email>Frederick.Hirsch@nokia.com</email>
+            </address>
           </author>
-          <author initials="J." surname="Kemp" fullname="John Kemp">
-            <organization/>
+          <author fullname="John Kemp" initials="J." surname="Kemp">
+            <organization>Nokia</organization>
+            <address>
+              <email>John.Kemp@nokia.com</email>
+            </address>
           </author>
-          <author initials="R." surname="Philpott"
-            fullname="Rob Philpott">
-            <organization/>
+          <author fullname="Rob Philpott" initials="R." surname="Philpott">
+            <organization>RSA Security</organization>
+            <address>
+              <email>rphilpott@rsasecurity.com</email>
+            </address>
           </author>
-          <author initials="E." surname="Mahler" fullname="Eve Mahler">
-            <organization/>
+          <author fullname="Eve Maler" initials="E." surname="Maler">
+            <organization>Sun Microsystems</organization>
+            <address>
+              <email>eve.maler@sun.com</email>
+            </address>
           </author>
-          <date day="15" month="March" year="2005"/>
+          <date year="2005" month="March"/>
         </front>
-        <seriesInfo name="OASIS Standard" value=""/>
+        <seriesInfo name="OASIS Standard" value="saml-bindings-2.0-os"/>
+        <format type="PDF" target="http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf"/>
       </reference>
     </references>
     <references title="Informative References">
-      <reference anchor="XACML"
-        target="http://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-cs-01-en.pdf">
+      <reference anchor="XACML" target="http://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-cs-01-en.pdf">
         <front>
           <title>eXtensible Access Control Markup Language (XACML)
             Version 3.0</title>
-          <author initials="E." surname="Rissanen"
-            fullname="Erik Rissanen">
+          <author initials="E." surname="Rissanen" fullname="Erik Rissanen">
             <organization/>
           </author>
           <date day="10" month="August" year="2010"/>
         </front>
       </reference>
-      <reference anchor="REST"
-        target="http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm">
+      <reference anchor="REST" target="http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm">
         <front>
           <title>Architectural Styles and the Design of Network-based
             Software Architectures</title>
@@ -849,9 +801,7 @@
           </author>
           <date year="2000"/>
         </front>
-        <format type="text/html"
-          target="http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm"
-          octets="7287"/>
+        <format type="text/html" target="http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm" octets="7287"/>
       </reference>
     </references>
     <section title="Use Case Examples">


### PR DESCRIPTION
Made tweaks to improve overall readability of the draft.
Changed the name of the CSIRT draft to use proper naming scheme.
Updated SAML references to contain more complete and correct
information.